### PR TITLE
Changes to support a global-rainbow-delimiters-mode

### DIFF
--- a/rainbow-delimiters.el
+++ b/rainbow-delimiters.el
@@ -477,6 +477,8 @@ Used by jit-lock for dynamic highlighting."
   :init-value (not (or noninteractive emacs-basic-display))
   :group 'rainbow-delimiters)
 
+;;;###autoload(custom-initialize-delay 'global-rainbow-delimiters-mode nil)
+
 (provide 'rainbow-delimiters)
 
 ;;; rainbow-delimiters.el ends here.

--- a/rainbow-delimiters.el
+++ b/rainbow-delimiters.el
@@ -459,6 +459,23 @@ Used by jit-lock for dynamic highlighting."
         (rainbow-delimiters-unpropertize-region (point-min) (1- (point-max))))
     (jit-lock-register 'rainbow-delimiters-propertize-region t)))
 
+(defun turn-on-rainbow-delimiters-if-desired ()
+  (when (cond ((eq font-lock-global-modes t)
+	       t)
+	      ((eq (car-safe font-lock-global-modes) 'not)
+	       (not (memq major-mode (cdr font-lock-global-modes))))
+	      (t (memq major-mode font-lock-global-modes)))
+    (let (inhibit-quit)
+      (rainbow-delimiters-mode t))))
+
+;;;###autoload
+(define-globalized-minor-mode global-rainbow-delimiters-mode
+  rainbow-delimiters-mode turn-on-rainbow-delimiters-if-desired
+  ;; What was this :extra-args thingy for?  --Stef
+  ;; :extra-args (dummy)
+  :initialize 'custom-initialize-delay
+  :init-value (not (or noninteractive emacs-basic-display))
+  :group 'rainbow-delimiters)
 
 (provide 'rainbow-delimiters)
 


### PR DESCRIPTION
I have made some changes to support a global-rainbow-delimiters-mode, on the lines of global-font-lock-mode. In fact, the code is copied from font-lock-core.el with all changes from font-lock to rainbow-delimiters. It works on my computer, but you may want to test too.
