### PR TITLE
Make (global-rainbow-delimiters-mode 1) work as intended.

### DIFF
--- a/rainbow-delimiters.el
+++ b/rainbow-delimiters.el
@@ -467,7 +467,7 @@ Used by jit-lock for dynamic highlighting."
 
 ;;;###autoload
 (define-globalized-minor-mode global-rainbow-delimiters-mode
-  rainbow-delimiters-mode rainbow-delimiters-mode)
+  rainbow-delimiters-mode (lambda () (rainbow-delimiters-mode 1)))
 
 (provide 'rainbow-delimiters)
 


### PR DESCRIPTION
Hi!

I like your recent addition of global-rainbow-delimiters-mode. Though it doesn't work well when turning mode on explicitly via `(global-rainbow-delimiters-mode 1)`. This is due to the following issue with `define-globalized-minor-mode`. The doc states:

<pre>
(define-globalized-minor-mode GLOBAL-MODE MODE TURN-ON &rest KEYS)

TURN-ON is a function that will be called with no args in every buffer
and that should try to turn MODE on if applicable for that buffer.
</pre>


Your code passes `rainbow-delimiter-mode` as `TURN-ON`, but `(rainbow-delimiter-mode)` _toggles_ the mode instead of _turning it on_.

I've wrote a little hack to fix this. Feel free to update the actual code in whatever way you like.
